### PR TITLE
bug fixed for primitive array unpack

### DIFF
--- a/py/hako_binary/binary_io.py
+++ b/py/hako_binary/binary_io.py
@@ -126,6 +126,30 @@ def binTovalue(type, arg):
         return binTostring(arg)
     else:
         return None
+def binToArrayValues(type, arg):
+    # little endian
+    if (type == "int8"):
+        return struct.unpack(f'<{len(arg)}b', arg)
+    elif (type == "uint8"):
+        return struct.unpack(f'<{len(arg)}B', arg)
+    elif (type == "int16"):
+        return struct.unpack(f'<{len(arg)//2}h', arg)
+    elif (type == "uint16"):
+        return struct.unpack(f'<{len(arg)//2}H', arg)
+    elif (type == "int32"):
+        return struct.unpack(f'<{len(arg)//4}i', arg)
+    elif (type == "uint32"):
+        return struct.unpack(f'<{len(arg)//4}I', arg)
+    elif (type == "int64"):
+        return struct.unpack(f'<{len(arg)//8}q', arg)
+    elif (type == "uint64"):
+        return struct.unpack(f'<{len(arg)//8}Q', arg)
+    elif (type == "float32"):
+        return struct.unpack(f'<{len(arg)//4}f', arg)
+    elif (type == "float64"):
+        return struct.unpack(f'<{len(arg)//8}d', arg)
+    else:
+        return None
 
 def writeBinary(binary_data, off, bin):
     i = 0

--- a/py/hako_binary/binary_reader.py
+++ b/py/hako_binary/binary_reader.py
@@ -34,7 +34,7 @@ def binary_read_recursive(offmap, binary_data, json_data, base_off, typename):
                 encode_type = "binary"
                 array_value = binary_io.readBinary(binary_data, off, size)
                 json_data[name + '_encode_type'] = encode_type
-                json_data[name] = array_value
+                json_data[name] = binary_io.binToArrayValues(type, array_value)
         else:
             if (offset_parser.is_single(line)):
                 tmp_json_data = {}

--- a/py/hako_robomodel_any.py
+++ b/py/hako_robomodel_any.py
@@ -57,10 +57,10 @@ class HakoRoboModelAny:
     def subscribe_pdu_lchannel(self, writers):
         for writer in writers:
             writer = ObjectLike(writer)
-            type = writer.type.split('/')[1]
+            typename = writer.type.split('/')[1]
             self.channel_map[writer.org_name] = writer.channel_id
-            #print("type=" + type)
-            #print("channel_id=" + str(writer.channel_id))
-            #print("pdu_size=" + str(writer.pdu_size))
-            self.hako.subscribe_pdu_lchannel(writer.channel_id, writer.pdu_size, 'JointState')
+            print("subscribe:channel_id=" + str(writer.channel_id))
+            print("subscribe:typename=" + typename)
+            print("subscribe:pdu_size=" + str(writer.pdu_size))
+            self.hako.subscribe_pdu_lchannel(writer.channel_id, writer.pdu_size, typename)
 


### PR DESCRIPTION
前回の修正だけでは不十分でしたので、あらためてPR出します。

https://github.com/toppers/hakoniwa-core-cpp-client/commit/0f68007ad26b37eb73701336b2fca2de2e6f0cc8

変更点：
* バイナリデータをpython用のデータ型の配列に変換する処理を追
  * binary_io.py/binToArrayValues(), binary_reader.py/binary_read_recursive()
* subscribeするデータのデータ型の指定が行われていなかったので修正
  * hako_robomode_any.py/subscribe_pdu_lchannel()