### PR TITLE
add raw member for binary access

### DIFF
--- a/py/hako_binary/binary_reader.py
+++ b/py/hako_binary/binary_reader.py
@@ -31,9 +31,8 @@ def binary_read_recursive(offmap, binary_data, json_data, base_off, typename):
                 json_data[name] = value
             else:
                 array_size = offset_parser.array_size(line)
-                encode_type = "binary"
                 array_value = binary_io.readBinary(binary_data, off, size)
-                json_data[name + '_encode_type'] = encode_type
+                json_data[name + '__raw' ] = array_value
                 json_data[name] = binary_io.binToArrayValues(type, array_value)
         else:
             if (offset_parser.is_single(line)):


### PR DESCRIPTION
以下の修正で、生のバイナリデータをtupple型に変換しましたが、
これだと uint8型の生データを直接アクセスしたい場合に無駄な逆変換を
しないといけなくなることに気づきました。


https://github.com/toppers/hakoniwa-core-cpp-client/pull/16

改善提案として、生のバイナリ データをそのまま `<メンバ名>__raw`　という形で
保持する修正をしてみましたので、ご確認ください。

あわせて、`encode_type` は不要と思えたので、削除しました。
