### PR TITLE
Remove json submodule

### DIFF
--- a/src/hakoc/CMakeLists.txt
+++ b/src/hakoc/CMakeLists.txt
@@ -21,7 +21,6 @@ message(STATUS "PYTHON_LIBRARIES:${PYTHON_LIBRARIES}" )
 message(STATUS "Python_LIBRARIES:${Python_LIBRARIES}" )
 message(STATUS "Python_LIBRARY_DIRS:${Python_LIBRARY_DIRS}" )
 
-
 add_library(
     hakoc
     src/hako_client.cpp
@@ -31,6 +30,10 @@ if(WIN32)
     set(OS_TYPE "win")
 endif(WIN32)
 MESSAGE(STATUS "OS_TYPE=" ${OS_TYPE})
+
+include(FetchContent)
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+FetchContent_MakeAvailable(json)
 
 add_library(
     shakoc SHARED
@@ -75,21 +78,21 @@ target_link_libraries(
 target_include_directories(
     hakoc
     PRIVATE /usr/local/include
-    PRIVATE ${HAKO_CORE_SOURCE_DIR}/third-party/json/single_include
     PRIVATE ${HAKO_CORE_SOURCE_DIR}/src/include
+    PRIVATE ${nlohmann_json_SOURCE_DIR}/single_include
 )
 
 target_include_directories(
     shakoc
     PRIVATE /usr/local/include
-    PRIVATE ${HAKO_CORE_SOURCE_DIR}/third-party/json/single_include
     PRIVATE ${HAKO_CORE_SOURCE_DIR}/src/include
     PRIVATE ${HAKO_CORE_SOURCE_DIR}/src/hako
+    PRIVATE ${nlohmann_json_SOURCE_DIR}/single_include
 )
 
 target_include_directories(
     hakoarun
     PRIVATE /usr/local/include
-    PRIVATE ${HAKO_CORE_SOURCE_DIR}/third-party/json/single_include
     PRIVATE ${HAKO_CORE_SOURCE_DIR}/src/include
+    PRIVATE ${nlohmann_json_SOURCE_DIR}/single_include
 )

--- a/src/proxy/CMakeLists.txt
+++ b/src/proxy/CMakeLists.txt
@@ -4,6 +4,9 @@ project(hako-proxy
     LANGUAGES C CXX
 )
 
+include(FetchContent)
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+FetchContent_MakeAvailable(json)
 
 add_executable(
     hako-proxy
@@ -16,10 +19,9 @@ target_link_libraries(
     -pthread
 )
 
-
 target_include_directories(
     hako-proxy 
     PRIVATE /usr/local/include
-    PRIVATE ${HAKO_CORE_SOURCE_DIR}/third-party/json/single_include
     PRIVATE ${HAKO_CORE_SOURCE_DIR}/src/include
+    PRIVATE ${nlohmann_json_SOURCE_DIR}/single_include
 )

--- a/src/proxy/src/rpc/CMakeLists.txt
+++ b/src/proxy/src/rpc/CMakeLists.txt
@@ -29,6 +29,9 @@ endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 find_package(Threads REQUIRED)
+include(FetchContent)
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+FetchContent_MakeAvailable(json)
 
 # This branch assumes that gRPC and all its dependencies are already installed
 # on this system, so they can be located by find_package().
@@ -82,7 +85,7 @@ add_custom_command(
 include_directories(
   "${CMAKE_CURRENT_BINARY_DIR}"
   "${PROJECT_SOURCE_DIR}/.."
-  "${PROJECT_SOURCE_DIR}/../../hakoniwa-core-cpp/third-party/json/single_include"
+  "${nlohmann_json_SOURCE_DIR}/single_include"
 )
 
 foreach(_target hako_rpc_client)


### PR DESCRIPTION
core-cppと同様の修正です．Cmakeの仕組みでjsonライブラリを引っ張ってきます．core-cppのPR（https://github.com/toppers/hakoniwa-core-cpp/pull/9）と一緒にご確認ください．
