### PR TITLE
Add include directory to installation script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, ubuntu-20.04, macos-latest, macos-13]
 
     steps:
       - name: Setup cmake
@@ -33,7 +33,7 @@ jobs:
       - name: Hakoniwa-core archive
         run: |
           bash install.bash
-          tar -czf hakoniwa-core-cpp-client_${{ env.OS_NAME }}_${{ env.OS_ARCH }}.tar.gz /usr/local/bin/hakoniwa /usr/local/lib/hakoniwa /var/lib/hakoniwa /etc/hakoniwa
+          tar -czf hakoniwa-core-cpp-client_${{ env.OS_NAME }}_${{ env.OS_ARCH }}.tar.gz /usr/local/bin/hakoniwa /usr/local/lib/hakoniwa /usr/local/include/hakoniwa /var/lib/hakoniwa /etc/hakoniwa
           ls -la
           echo "ARTIFACT_ARCHIVE_PATH=hakoniwa-core-cpp-client_${{ env.OS_NAME }}_${{ env.OS_ARCH }}.tar.gz" >> $GITHUB_ENV
 
@@ -52,7 +52,7 @@ jobs:
       - name: upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: hakoniwa-core-cpp-client_${{ env.OS_NAME }}_${{ env.OS_ARCH }}
+          name: hakoniwa-core-cpp-client_${{ env.OS_NAME }}_${{ env.OS_ARCH }}_${{ matrix.os }}
           path: |
             ${{env.ARTIFACT_PATH}}
             ${{env.ARTIFACT_ARCHIVE_PATH}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-20.04, macos-latest, macos-13]
 

--- a/install.bash
+++ b/install.bash
@@ -34,7 +34,7 @@ fi
 ${SUDO} cp cmake-build/src/assets/libassets.* /usr/local/lib/hakoniwa/
 ${SUDO} cp cmake-build/src/conductor/libconductor.* /usr/local/lib/hakoniwa/
 
-${SUDO} cp -rp src/include /usr/local/include/hakoniwa/
+${SUDO} cp src/include/*.h /usr/local/include/hakoniwa/
 ${SUDO} cp -rp py /usr/local/lib/hakoniwa/
 if [ ${OS_TYPE} = "posix" ]
 then

--- a/install.bash
+++ b/install.bash
@@ -55,6 +55,7 @@ else
 fi
 ${SUDO} cp cmake-build/src/assets/libassets.* /usr/local/lib/hakoniwa/
 ${SUDO} cp cmake-build/src/conductor/libconductor.* /usr/local/lib/hakoniwa/
+${SUDO} cp -rp src/include /usr/local/include/hakoniwa/
 
 ${SUDO} cp -rp py /usr/local/lib/hakoniwa/
 if [ ${OS_TYPE} = "posix" ]

--- a/install.bash
+++ b/install.bash
@@ -13,35 +13,13 @@ else
     OS_TYPE="win"
 	SUDO=
 fi
-if [ ! -d /usr/local/bin ]
-then
-	${SUDO} mkdir /usr/local/bin
-fi
-if [ ! -d /usr/local/lib ]
-then
-	${SUDO} mkdir /usr/local/lib
-fi
 
-if [ ! -d /usr/local/bin/hakoniwa ]
-then
-	${SUDO} mkdir /usr/local/bin/hakoniwa
-fi
-if [ ! -d /usr/local/lib/hakoniwa ]
-then
-	${SUDO} mkdir /usr/local/lib/hakoniwa
-fi
-if [ ! -d /etc/hakoniwa ]
-then
-	${SUDO} mkdir /etc/hakoniwa
-fi
-if [ ! -d /var/lib/hakoniwa ]
-then
-	${SUDO} mkdir /var/lib/hakoniwa
-fi
-if [ ! -d /var/lib/hakoniwa/mmap ]
-then
-	${SUDO} mkdir /var/lib/hakoniwa/mmap
-fi
+${SUDO} mkdir -p /usr/local/bin/hakoniwa
+${SUDO} mkdir -p /usr/local/lib/hakoniwa
+${SUDO} mkdir -p /usr/local/include/hakoniwa
+${SUDO} mkdir -p /etc/hakoniwa
+${SUDO} mkdir -p /var/lib/hakoniwa/mmap
+
 ${SUDO} cp core/cpp_core_config.json /etc/hakoniwa/
 
 ${SUDO} cp cmake-build/core/sample/base-procs/hako-cmd/hako-cmd /usr/local/bin/hakoniwa/
@@ -55,8 +33,8 @@ else
 fi
 ${SUDO} cp cmake-build/src/assets/libassets.* /usr/local/lib/hakoniwa/
 ${SUDO} cp cmake-build/src/conductor/libconductor.* /usr/local/lib/hakoniwa/
-${SUDO} cp -rp src/include /usr/local/include/hakoniwa/
 
+${SUDO} cp -rp src/include /usr/local/include/hakoniwa/
 ${SUDO} cp -rp py /usr/local/lib/hakoniwa/
 if [ ${OS_TYPE} = "posix" ]
 then


### PR DESCRIPTION
install.bashの処理でsrc/include以下のヘッダファイルを `/usr/local/include/hakoniwa`
にコピーする処理を追加しました。

アセット作成者がバイナリアーカイブのみでアセット開発を行えるようになる想定です。
