### PR TITLE
Add test project of hako_asset library

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -1,0 +1,7 @@
+{
+  "AssetDumy": [
+    {
+      "name": "AssetDumy"
+    }
+  ]
+}

--- a/test/hakoAsset-01/CMakeLists.txt
+++ b/test/hakoAsset-01/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Set the project name and the version of C++ to use.
+project(hako_asset_test_project VERSION 1.0 LANGUAGES CXX)
+
+# Set the C++ standard.
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+set(TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(HOME_DIR ${TEST_DIR}/../..)
+
+# Download and build Google Test.
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        release-1.10.0
+)
+FetchContent_MakeAvailable(googletest)
+
+include_directories(
+  ${HOME_DIR}/src/include
+  ${HOME_DIR}/core/src/include
+  ${HOME_DIR}/core/third-party/json/include
+)
+
+# Specify the source code for the test and the test code.
+set(SOURCE_FILES
+  ${HOME_DIR}/src/assets/src/hako_asset.cpp
+  ${HOME_DIR}/src/assets/src/hako_asset_impl.cpp
+  ./test.cpp
+)
+
+link_directories(/usr/local/lib/hakoniwa)
+
+# Generate an executable file.
+add_executable(test ${SOURCE_FILES})
+
+# Link with the Google Test and hakoniwa core library.
+target_link_libraries( test
+  gtest_main
+  assets
+  conductor
+)

--- a/test/hakoAsset-01/test.cpp
+++ b/test/hakoAsset-01/test.cpp
@@ -1,0 +1,57 @@
+#include "gtest/gtest.h"
+// ここにはテスト対象のヘッダーファイルをインクルードします。
+#include "hako_asset.h"
+#include "hako_conductor.h"
+
+// コールバック関数の実装
+static int my_on_initialize(hako_asset_context_t* context)
+{
+    std::cout << "INFO: my_on_initialize enter" << std::endl;
+    return 0;
+}
+
+static int my_on_reset(hako_asset_context_t* context)
+{
+    std::cout << "INFO: my_on_reset enter" << std::endl;
+    return 0;
+}
+
+static int my_on_simulation_step(hako_asset_context_t* context)
+{
+    std::cout << "INFO: on_simulation_step enter: " << hako_asset_simulation_time() << std::endl;
+    std::cout << "INFO: sleep 1sec" << std::endl;
+    usleep(1000*1000);
+    std::cout << "INFO: on_simulation_step exit" << std::endl;
+    return 0;
+}
+
+hako_asset_callbacks_t callbacks = {
+    .on_initialize = my_on_initialize,
+    .on_simulation_step = my_on_simulation_step,
+    .on_reset = my_on_reset
+};
+
+hako_time_t delta_time_usec = 1000 * 1000 * 100;
+
+TEST(HakoCApiTest, AssetRegist) {
+    hako_conductor_start(delta_time_usec, delta_time_usec);
+    int result = hako_asset_register("AssetDumy", "../../config.json", &callbacks,  1000, HAKO_ASSET_MODEL_CONTROLLER);
+    ASSERT_EQ(result, 0);
+}
+
+TEST(HakoCApiTest, AssetStart) {
+    int result = hako_asset_start();
+    ASSERT_EQ(result, EINTR);   // Resetで終了するのでEINTRが返る
+}
+
+TEST(HakoCApiTest, ConductorStop) {
+    hako_conductor_stop();
+    // ASSERT_EQ(result, 0);
+}
+
+
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/hakoAsset-01/test.cpp
+++ b/test/hakoAsset-01/test.cpp
@@ -1,4 +1,6 @@
 #include "gtest/gtest.h"
+#include <thread>
+#include <chrono>
 // ここにはテスト対象のヘッダーファイルをインクルードします。
 #include "hako_asset.h"
 #include "hako_conductor.h"
@@ -33,6 +35,15 @@ hako_asset_callbacks_t callbacks = {
 
 hako_time_t delta_time_usec = 1000 * 1000 * 100;
 
+void run_hako_cmd_sequence() {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::system("/usr/local/bin/hakoniwa/hako-cmd start");
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+    std::system("/usr/local/bin/hakoniwa/hako-cmd stop");
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::system("/usr/local/bin/hakoniwa/hako-cmd reset");
+}
+
 TEST(HakoCApiTest, AssetRegist) {
     hako_conductor_start(delta_time_usec, delta_time_usec);
     int result = hako_asset_register("AssetDumy", "../../config.json", &callbacks,  1000, HAKO_ASSET_MODEL_CONTROLLER);
@@ -40,6 +51,10 @@ TEST(HakoCApiTest, AssetRegist) {
 }
 
 TEST(HakoCApiTest, AssetStart) {
+    // Execute the external command to launch the sandbox in a separate thread
+    std::thread t(run_hako_cmd_sequence);
+    t.detach();
+
     int result = hako_asset_start();
     ASSERT_EQ(result, EINTR);   // Resetで終了するのでEINTRが返る
 }


### PR DESCRIPTION
hako_assetを使用したC++ API のテストプログラムです。
起動時にhako-cmdが別途必要です。 -> これは 89ad504caedb4f52758f49eecf1b4a7ec6e31790 でhako_cmdを実行する別スレッドをテストに組み入れました