### PR TITLE
Fix: Adjust Windows Build compatibility for core-cpp-client

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -15,10 +15,11 @@ then
     if [ ${OS_TYPE} = "posix" ]
     then
         cmake ..
+        make
     else
-        cmake .. -G "Unix Makefiles" -D WIN32=true
+        cmake ..
+        cmake --build . --target ALL_BUILD --config Release
     fi
-	make
 else
 	rm -rf ./cmake-build/*
 fi

--- a/install.bash
+++ b/install.bash
@@ -28,8 +28,6 @@ ${SUDO} mkdir -p ${HAKONIWA_DIR}
 if [ "$OS" = "Linux" -o "$OS" = "Darwin"  ]
 then
 	${SUDO} mkdir -p /var/lib/hakoniwa/mmap
-else
-	${SUDO} mkdir -p /c/mmap
 fi
 
 ${SUDO} cp core/cpp_core_config.json ${HAKONIWA_DIR}

--- a/install.bash
+++ b/install.bash
@@ -1,6 +1,8 @@
 #!/bin/bash
 OS_TYPE="posix"
 OS=`uname`
+INSTALL_DIR=""
+HAKONIWA_DIR=""
 if [ "$OS" = "Linux" -o "$OS" = "Darwin"  ]
 then
 	SUDO=
@@ -9,33 +11,58 @@ then
 	then
 		SUDO=sudo
 	fi
+	INSTALL_DIR="/usr/local"
+	HAKONIWA_DIR="/etc/hakoniwa"
 else
     OS_TYPE="win"
 	SUDO=
+	INSTALL_DIR="../local"
+	HAKONIWA_DIR="../hakoniwa"
 fi
 
-${SUDO} mkdir -p /usr/local/bin/hakoniwa
-${SUDO} mkdir -p /usr/local/lib/hakoniwa
-${SUDO} mkdir -p /usr/local/include/hakoniwa
-${SUDO} mkdir -p /etc/hakoniwa
-${SUDO} mkdir -p /var/lib/hakoniwa/mmap
+${SUDO} mkdir -p ${INSTALL_DIR}/bin/hakoniwa
+${SUDO} mkdir -p ${INSTALL_DIR}/lib/hakoniwa
+${SUDO} mkdir -p ${INSTALL_DIR}/include/hakoniwa
+${SUDO} mkdir -p ${HAKONIWA_DIR}
 
-${SUDO} cp core/cpp_core_config.json /etc/hakoniwa/
+if [ "$OS" = "Linux" -o "$OS" = "Darwin"  ]
+then
+	${SUDO} mkdir -p /var/lib/hakoniwa/mmap
+else
+	${SUDO} mkdir -p /c/mmap
+fi
 
-${SUDO} cp cmake-build/core/sample/base-procs/hako-cmd/hako-cmd /usr/local/bin/hakoniwa/
-${SUDO} cp cmake-build/src/hakoc/libhakoarun.* /usr/local/lib/hakoniwa/
-${SUDO} cp cmake-build/src/hakoc/libshakoc.* /usr/local/lib/hakoniwa/
+${SUDO} cp core/cpp_core_config.json ${HAKONIWA_DIR}
+
 if [ "$OS" = "Darwin"  ]
 then
-	${SUDO} cp cmake-build/src/hakoc/libshakoc.dylib /usr/local/lib/hakoniwa/hakoc.so
+	${SUDO} cp cmake-build/core/sample/base-procs/hako-cmd/hako-cmd ${INSTALL_DIR}/bin/hakoniwa/
+	${SUDO} cp cmake-build/src/hakoc/libhakoarun.* ${INSTALL_DIR}/lib/hakoniwa/
+	${SUDO} cp cmake-build/src/hakoc/libshakoc.* ${INSTALL_DIR}/lib/hakoniwa/
+	${SUDO} cp cmake-build/src/hakoc/libshakoc.dylib ${INSTALL_DIR}/lib/hakoniwa/hakoc.so
+	${SUDO} cp cmake-build/src/assets/libassets.* ${INSTALL_DIR}/lib/hakoniwa/
+	${SUDO} cp cmake-build/src/conductor/libconductor.* ${INSTALL_DIR}/lib/hakoniwa/
+elif [ "$OS" = "Linux"  ]
+then
+	${SUDO} cp cmake-build/core/sample/base-procs/hako-cmd/hako-cmd ${INSTALL_DIR}/bin/hakoniwa/
+	${SUDO} cp cmake-build/src/hakoc/libhakoarun.* ${INSTALL_DIR}/lib/hakoniwa/
+	${SUDO} cp cmake-build/src/hakoc/libshakoc.* ${INSTALL_DIR}/lib/hakoniwa/
+	${SUDO} cp cmake-build/src/hakoc/libshakoc.* ${INSTALL_DIR}/lib/hakoniwa/hakoc.so
+	${SUDO} cp cmake-build/src/assets/libassets.* ${INSTALL_DIR}/lib/hakoniwa/
+	${SUDO} cp cmake-build/src/conductor/libconductor.* ${INSTALL_DIR}/lib/hakoniwa/
 else
-	${SUDO} cp cmake-build/src/hakoc/libshakoc.* /usr/local/lib/hakoniwa/hakoc.so
+	${SUDO} cp cmake-build/core/sample/base-procs/hako-cmd/Release/hako-cmd.exe ${INSTALL_DIR}/bin/hakoniwa/
+	${SUDO} cp cmake-build/core/src/Release/hako.* ${INSTALL_DIR}/lib/hakoniwa/
+	${SUDO} cp cmake-build/src/hakoc/Release/hakoarun.* ${INSTALL_DIR}/lib/hakoniwa/
+	${SUDO} cp cmake-build/src/hakoc/Release/shakoc.* ${INSTALL_DIR}/lib/hakoniwa/
+	${SUDO} cp cmake-build/src/hakoc/Release/hakoc.* ${INSTALL_DIR}/lib/hakoniwa/
+	${SUDO} cp cmake-build/src/assets/Release/assets.* ${INSTALL_DIR}/lib/hakoniwa/
+	${SUDO} cp cmake-build/src/conductor/Release/conductor.* ${INSTALL_DIR}/lib/hakoniwa/
 fi
-${SUDO} cp cmake-build/src/assets/libassets.* /usr/local/lib/hakoniwa/
-${SUDO} cp cmake-build/src/conductor/libconductor.* /usr/local/lib/hakoniwa/
 
-${SUDO} cp src/include/*.h /usr/local/include/hakoniwa/
-${SUDO} cp -rp py /usr/local/lib/hakoniwa/
+${SUDO} cp src/include/* ${INSTALL_DIR}/include/hakoniwa/
+${SUDO} cp -rp py ${INSTALL_DIR}/lib/hakoniwa/
+
 if [ ${OS_TYPE} = "posix" ]
 then
 	${SUDO} cp cmake-build/src/proxy/hako-proxy /usr/local/bin/hakoniwa/
@@ -51,4 +78,7 @@ else
 fi
 
 # ディレクトリのパーミッションを適切に設定
-${SUDO} chmod -R 755 /var/lib/hakoniwa
+if [ "$OS" = "Linux" -o "$OS" = "Darwin"  ]
+then
+	${SUDO} chmod -R 755 /var/lib/hakoniwa
+fi


### PR DESCRIPTION
hakoniwa-core-cpp-clientのWindows Build対応です。
Linux側には、影響ないようにしているつもりです。