### PR TITLE
chore: Update devcontainer configuration for C++ development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "git submodule update --init --recursive",
+	"postCreateCommand": "git config --global --add safe.directory /workspaces/hakoniwa-core-cpp-client && git submodule update --init --recursive",
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
gitのアクセス権の課題でsubmodulesがhttpsアクセスだと`safe.deirectory` 設定をしないとうまく行かない。
ただ全ての人がSSH設定をしているわけでは無い（2FAはしていると思うが）ので、submodulesはそのままにして、git configでカバーする。