### PR TITLE
Add Windows setup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,14 @@ bash hako-setup-check.bash
 成功している場合は、以下のログが出力されます。
 
 ```
+=== HAKO ENV ===
+OS=Linux , OS_TYPE=posix
+HAKO_CORE_PREFIX=/usr/local
+HAKO_CONFIG_PREFIX=/etc/hakoniwa
+HAKO_CORE_MMAP_PREFIX=/var/lib/hakoniwa
+HAKO_CONFIGNFIG_PATH=/etc/hakoniwa/cpp_core_config.json
+HAKO_CORE_MMAP_PATH=/var/lib/hakoniwa/mmap
+
 OK Directory exists: /usr/local/bin
 OK Directory exists: /usr/local/bin/hakoniwa
 OK Directory exists: /usr/local/lib
@@ -786,6 +794,68 @@ MMAPファイルは、`core_mmap_path`  配下に自動作成されます。
 また、MMAPファイルを `ramdisk` に配置するこで、処理性能を向上させることができます。
 
 作成した `ramdisk` パスを `hako-mmap-set.bat` で再設定することで反映されます。
+
+# Windows向け(gitbash)インストール手順
+
+Windows 向けに箱庭コア機能をインストールする場合、以下のツールを利用します。
+
+* Visual Studio Build Tools
+* Git for Windows
+* CMake
+* [Python 3.12](https://www.python.org/)
+* jq
+
+## wingetコマンドでのツールのインストール
+コマンドプロンプトもしくはPowerShellからwingetコマンドを用いてツールをインストールします。
+
+**Visual Studio Build Tools:**
+```
+winget install Microsoft.VisualStudio.2022.BuildTools --override "--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+```
+
+**Git for Windows**
+```
+winget install --id Git.Git -e --source winget
+```
+
+**CMake:**
+```
+winget install Kitware.CMake
+```
+
+**Python**
+```
+winget install Python.Python.3.12
+```
+
+**jq**
+```
+winget install jqlang.jq
+```
+## クローンとビルド
+Git for WindowsのGit Bashを使用します。
+VSCodeを起動するとTerminalの選択で「Git Bash」を選びます
+
+**ビルド:**
+
+```
+cd hakoniwa-core-cpp-client
+```
+
+```
+bash build.bash
+```
+
+**インストール:**
+
+```
+bash install.bash
+```
+**設定の確認:**
+
+```
+bash ./hako-setup-check.bash 
+```
 
 # 箱庭コマンド API
 

--- a/hako-setup-check.bash
+++ b/hako-setup-check.bash
@@ -2,39 +2,86 @@
 
 STATUS="OK"
 
-# 必要なディレクトリのリスト
-directories=(
-    "/usr/local/bin"
-    "/usr/local/bin/hakoniwa"
-    "/usr/local/lib"
-    "/usr/local/lib/hakoniwa"
-    "/etc/hakoniwa"
-    "/var/lib/hakoniwa"
-    "/var/lib/hakoniwa/mmap"
-)
 OS=`uname`
 if [ "$OS" = "Linux" ]; then
+    OS_TYPE="posix"
     LIB_EXT=".so"
+    LIB_PRE="lib"
 elif [ "$OS" = "Darwin" ]; then
+    OS_TYPE="posix"
     LIB_EXT=".dylib"
+    LIB_PRE="lib"
 else
-    LIB_EXT=".so"
+    OS_TYPE="win"
+    LIB_EXT=".lib"
+    LIB_PRE=""
 fi
+
+# デフォルトの箱庭環境変数
+if [ -z "$HAKO_CORE_PREFIX" ]; then
+    if [ "$OS_TYPE" = "posix" ]; then
+        HAKO_CORE_PREFIX="/usr/local"
+    else
+        HAKO_CORE_PREFIX="../local"
+    fi
+fi
+
+if [ -z "$HAKO_CONFIG_PATH" ]; then
+    if [ "$OS_TYPE" = "posix" ]; then
+        HAKO_CONFIG_PREFIX="/etc/hakoniwa"
+    else
+        HAKO_CONFIG_PREFIX="../hakoniwa"
+    fi
+    HAKO_CONFIG_PATH="$HAKO_CONFIG_PREFIX/cpp_core_config.json"
+fi
+
+if [ -z "$HAKO_CORE_MMAP_PATH" ]; then
+    if [ "$OS_TYPE" = "posix" ]; then
+        HAKO_CORE_MMAP_PREFIX="/var/lib/hakoniwa"
+    else
+        HAKO_CORE_MMAP_PREFIX="/z"
+    fi
+    HAKO_CORE_MMAP_PATH="$HAKO_CORE_MMAP_PREFIX/mmap"
+fi
+
+#
+echo "=== HAKO ENV ==="
+echo "OS=$OS , OS_TYPE=$OS_TYPE"
+echo "HAKO_CORE_PREFIX=$HAKO_CORE_PREFIX"
+echo "HAKO_CONFIG_PREFIX=$HAKO_CONFIG_PREFIX"
+echo "HAKO_CORE_MMAP_PREFIX=$HAKO_CORE_MMAP_PREFIX"
+echo "HAKO_CONFIGNFIG_PATH=$HAKO_CONFIG_PATH"
+echo "HAKO_CORE_MMAP_PATH=$HAKO_CORE_MMAP_PATH"
+echo ""
+
+# 必要なディレクトリのリスト
+directories=(
+    "$HAKO_CORE_PREFIX/bin"
+    "$HAKO_CORE_PREFIX/bin/hakoniwa"
+    "$HAKO_CORE_PREFIX/lib"
+    "$HAKO_CORE_PREFIX/lib/hakoniwa"
+    "$HAKO_CONFIG_PREFIX"
+    "$HAKO_CORE_MMAP_PREFIX"
+    "$HAKO_CORE_MMAP_PREFIX/mmap"
+)
 
 # OSに応じたファイルのリスト
 files=(
-    "/etc/hakoniwa/cpp_core_config.json"
-    "/usr/local/bin/hakoniwa/hako-cmd"
-    "/usr/local/lib/hakoniwa/libhakoarun.a"
-    "/usr/local/lib/hakoniwa/libshakoc$LIB_EXT"
-    "/usr/local/lib/hakoniwa/hakoc.so" # このファイル名は固定
-    "/usr/local/lib/hakoniwa/libassets$LIB_EXT"
-    "/usr/local/lib/hakoniwa/libconductor$LIB_EXT"
-    "/usr/local/lib/hakoniwa/py" # ディレクトリのチェック
+    "$HAKO_CONFIG_PATH"
+    "$HAKO_CORE_PREFIX/bin/hakoniwa/hako-cmd"
+    "$HAKO_CORE_PREFIX/lib/hakoniwa/${LIB_PRE}shakoc$LIB_EXT"
+    "$HAKO_CORE_PREFIX/lib/hakoniwa/${LIB_PRE}assets$LIB_EXT"
+    "$HAKO_CORE_PREFIX/lib/hakoniwa/${LIB_PRE}conductor$LIB_EXT"
+    "$HAKO_CORE_PREFIX/lib/hakoniwa/py" # ディレクトリのチェック
 )
 
 if [ "$(uname)" = "Linux" -o "$(uname)" = "Darwin" ]; then
-    files+=("/usr/local/bin/hakoniwa/hako-proxy")
+    files+=("$HAKO_CORE_PREFIX/bin/hakoniwa/hako-proxy")
+    files+=("$HAKO_CORE_PREFIX/lib/hakoniwa/hakoc.so") # このファイル名は固定
+    files+=("$HAKO_CORE_PREFIX/lib/hakoniwa/${LIB_PRE}hakoarun.a")
+else    # Windows
+    files+=("$HAKO_CORE_PREFIX/lib/hakoniwa/hakoc.lib") # このファイル名は固定
+    files+=("$HAKO_CORE_PREFIX/lib/hakoniwa/${LIB_PRE}hakoarun.lib")
 fi
 
 # ディレクトリの存在をチェック


### PR DESCRIPTION
MSVCとGit Bash(Git for Windowws)を使った場合のWindowsネイティブの設定方法を追加しました。
bashスクリプトだけで利用できます。
あわせて、hako-setup-check.bashをposixとwinで両方使えるようにしました。

ただし、HAKO_CONFIG_PATH　の設定は行っていません。